### PR TITLE
Placeholder arg greedy for placeholders w/ spaces

### DIFF
--- a/src/main/java/com/mrivanplays/papisigns/command/BaseCommand.java
+++ b/src/main/java/com/mrivanplays/papisigns/command/BaseCommand.java
@@ -52,7 +52,7 @@ public class BaseCommand {
                     .build(),
                 ArgumentDescription.of("The line to manipulate"))
             .argument(
-                StringArgument.<CommandSender>builder("placeholder").single().asRequired().build(),
+                StringArgument.<CommandSender>builder("placeholder").greedy().asRequired().build(),
                 ArgumentDescription.of("The placeholder you want to be displayed"))
             .handler(
                 context -> {


### PR DESCRIPTION
It's possible to create a placeholder that has spaces in it, like the ones for [PlayerStats](https://github.com/Artemis-the-gr8/PlayerStatsExpansion).